### PR TITLE
昼寝ステータス追加

### DIFF
--- a/lib/lang/en.js
+++ b/lib/lang/en.js
@@ -42,6 +42,7 @@ export const defaultStatuses = [
   { message: 'During a telephone call', emoji: ':telephone_receiver:' },
   { message: 'During a meal', emoji: ':rice:' },
   { message: 'During a break', emoji: ':coffee:' },
+  { message: 'During a nap', emoji: ':sleeping:' },
   { message: 'During the move', emoji: ':train:' },
   { message: 'Away', emoji: ':no_bell:' },
   { message: 'Concentrated has', emoji: ':name_badge:' },

--- a/lib/lang/ja.js
+++ b/lib/lang/ja.js
@@ -42,6 +42,7 @@ export const defaultStatuses = [
   { message: '電話中です', emoji: ':telephone_receiver:' },
   { message: '食事中です', emoji: ':rice:' },
   { message: '休憩中です', emoji: ':coffee:' },
+  { message: '昼寝中です', emoji: ':sleeping:' },
   { message: '移動中です', emoji: ':train:' },
   { message: '離席中です', emoji: ':no_bell:' },
   { message: '集中してます', emoji: ':name_badge:' },


### PR DESCRIPTION
お昼寝常用ユーザとしては、お昼寝ステータスも欲しいのですが、 `休憩中です` と若干意味が被る感じがしないでもないので、不要であれば close してください。

Screenshot:
<img width="183" alt="screen shot 2015-10-16 at 13 11 44" src="https://cloud.githubusercontent.com/assets/1732016/10533673/96376934-7407-11e5-92e9-c95c2dec85d7.png">
